### PR TITLE
fix typo in `ps f` command results

### DIFF
--- a/007.md
+++ b/007.md
@@ -130,8 +130,8 @@ ps コマンドで様子を見てみましょう
     $ ps f
       PID TTY      STAT   TIME COMMAND
     16753 pts/2    Ss     0:00 -bash
-    16891 pts/2    S      0:00  \_ perl hoge.pl
-    16892 pts/2    S      0:00  |   \_ perl hoge.pl
+    16891 pts/2    S      0:00  \_ perl fork_and_sleep.pl
+    16892 pts/2    S      0:00  |   \_ perl fork_and_sleep.pl
     16928 pts/2    R+     0:00  \_ ps f
 
 「f」を付けて ps を実行すると親子関係が一目でわかります。この場合は 16891 が親プロセス、16892 が子プロセスですね。では、fg でフォアグラウンドに戻して、Ctrl + C を押してみましょう。Ctrl+C は、プロセスに対してSIGINTを送信します。
@@ -151,8 +151,8 @@ OKですか？ そうしたら、ここで再度 ps を実行してみましょ�
     $ ps -f
       PID TTY      STAT   TIME COMMAND
     16753 pts/2    Ss     0:00 -bash
-    17288 pts/2    S      0:00  \_ perl hoge.pl
-    17289 pts/2    S      0:00  |   \_ perl hoge.pl
+    17288 pts/2    S      0:00  \_ perl fork_and_sleep.pl
+    17289 pts/2    S      0:00  |   \_ perl fork_and_sleep.pl
     17293 pts/2    R+     0:00  \_ ps f
 
     $ kill -INT 17288 # 親プロセスにSIGINTを送る
@@ -161,7 +161,7 @@ OKですか？ そうしたら、ここで再度 ps を実行してみましょ�
       PID TTY      STAT   TIME COMMAND
     16753 pts/2    Ss     0:00 -bash
     17352 pts/2    R+     0:00  \_ ps f
-    17289 pts/2    S      0:00 perl hoge.pl
+    17289 pts/2    S      0:00 perl fork_and_sleep.pl
 
 *「！？」* 今度は子プロセスが残っています（親プロセスが死んだからinitの子供になっており、ツリーの表示も変わっています）。
 


### PR DESCRIPTION
`ps f`コマンドの実行結果の中の*.plファイル名が実行したファイル名と異なっていたため修正する。