### PR TITLE
GitHub Pagesへの自動デプロイワークフローを追加

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: true
+    
+    - name: Build HTML
+      run: bundle exec rake html
+    
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+    
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: './release'
+  
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 概要
- GitHub Pagesへの自動デプロイを行うワークフローを追加
- masterブランチへのpush時、または手動実行時に動作
- ビルドしたHTMLファイルをGitHub Pagesにデプロイ

## テストプラン
- [ ] ワークフローのYAML構文が正しいことを確認
- [ ] GitHub Pagesの設定を有効化後、正常にデプロイされることを確認
- [ ] 手動実行でも動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)