### PR TITLE
GitHub ActionsでのPDF生成エラーを修正

### DIFF
--- a/script/generate_pdf.js
+++ b/script/generate_pdf.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 
 async function generatePDF() {
-  const htmlPath = path.join(__dirname, '..', 'release', 'process_book.html');
+  const htmlPath = path.join(__dirname, '..', 'release', 'index.html');
   const pdfPath = path.join(__dirname, '..', 'release', 'process_book.pdf');
 
   // HTMLファイルが存在するか確認


### PR DESCRIPTION
## 概要
GitHub ActionsでPDF生成が失敗していた問題を修正

## 問題
- `generate_pdf.js`が`release/process_book.html`を参照していた
- しかし、`rake html`で生成されるのは`release/index.html`
- ファイルが見つからずエラーになっていた

## 修正内容
- `generate_pdf.js`で参照するファイル名を`index.html`に変更

## 動作確認
- この修正によりGitHub ActionsでのPDF生成が成功するようになります

🤖 Generated with [Claude Code](https://claude.ai/code)