### PR TITLE
PDFの余白を削減して紙面を有効活用

### DIFF
--- a/script/generate_pdf.js
+++ b/script/generate_pdf.js
@@ -33,10 +33,10 @@ async function generatePDF() {
       format: 'A4',
       printBackground: true,
       margin: {
-        top: '30mm',
-        right: '25mm',
-        bottom: '30mm',
-        left: '25mm'
+        top: '10mm',
+        right: '0mm',
+        bottom: '10mm',
+        left: '0mm'
       }
     });
 


### PR DESCRIPTION
## Summary
- PDF生成時の余白設定を最適化
- HTMLで既に設定されている余白を活かすため、PDF側の余白を最小限に

## 変更内容
- 左右の余白: 25mm → 0mm（HTMLのスタイルで十分）
- 上下の余白: 30mm → 10mm（改ページのために最小限確保）

## Test plan
- [ ] `rake` でPDFを生成
- [ ] 生成されたPDFの余白が適切か確認
- [ ] テキストが切れていないか確認

🤖 Generated with [Claude Code](https://claude.ai/code)