### PR TITLE
Pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,33 +20,33 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
       with:
         ruby-version-file: '.ruby-version'
         bundler-cache: true
-    
+
     - name: Build HTML
       run: bundle exec rake html
-    
+
     - name: Setup Pages
-      uses: actions/configure-pages@v5
-    
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
       with:
         path: './release'
-  
+
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    
+
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
     - name: Generate release tag with JST datetime
       id: generate_tag
       run: |
@@ -17,15 +17,15 @@ jobs:
         JST_DATETIME=$(TZ='Asia/Tokyo' date +'%Y-%m-%d-%H-%M-%S')
         echo "tag_name=${JST_DATETIME}" >> $GITHUB_OUTPUT
         echo "Generated tag: ${JST_DATETIME}"
-    
+
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
       with:
         ruby-version: '3.0'
         bundler-cache: true
-    
+
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20'
     
@@ -47,7 +47,7 @@ jobs:
       run: node script/generate_pdf.js
     
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       with:
         tag_name: ${{ steps.generate_tag.outputs.tag_name }}
         name: Release ${{ steps.generate_tag.outputs.tag_name }}


### PR DESCRIPTION
## Summary
This PR pins all GitHub Actions dependencies to their specific commit SHAs while maintaining version tags as comments for readability. This improves supply chain security by preventing unexpected changes from action updates.

## Key Changes
- **github-pages.yml**: Pinned 5 actions to specific commits:
  - `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5`
  - `ruby/setup-ruby@v1` → `319994f95fa847cf3fb3cd3dbe89f6dcde9f178f`
  - `actions/configure-pages@v5` → `983d7736d9b0ae728b81ab479565c72886d7745b`
  - `actions/upload-pages-artifact@v3` → `56afc609e74202658d3ffba0e8f6dda462b719fa`
  - `actions/deploy-pages@v4` → `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e`

- **release.yml**: Pinned 4 actions to specific commits:
  - `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5`
  - `ruby/setup-ruby@v1` → `319994f95fa847cf3fb3cd3dbe89f6dcde9f178f`
  - `actions/setup-node@v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020`
  - `softprops/action-gh-release@v1` → `de2c0eb89ae2a093876385947365aca7b0e5f844`

- Fixed trailing whitespace inconsistencies in both workflow files

## Implementation Details
Each action reference now uses the format: `action@<commit-sha> # <version-tag>` which provides:
- **Security**: Explicit commit pinning prevents unauthorized action modifications
- **Readability**: Version tags in comments maintain clarity about which version is being used
- **Auditability**: Commit SHAs enable precise tracking of what code is executing

https://claude.ai/code/session_011GQw4ZVs6xB2s1UFN54Boc